### PR TITLE
Switch to using a declarative Jenkinsfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 /debian/debhelper-build-stamp
 /debian/files
 /debian/libpam-trimspaces
-/dist
+/dist*
 /pam_trimspaces.so

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,62 +1,73 @@
-try {
-    stage('check-out-code') {
-        node('slave') {
-            dir('src') {
-                checkout scm
-            }
-            stash 'src'
-        }
+def dists = ['stretch', 'buster']
+
+def parallelBuilds = dists.collectEntries { dist ->
+  [dist, {
+    stage("build-${dist}") {
+      sh 'make clean'
+      sh "make package_${dist}"
+      archiveArtifacts artifacts: "dist_${dist}/*"
     }
-
-
-    // array.each doesn't work in jenkins, wtf
-    // https://issues.jenkins-ci.org/browse/JENKINS-26481
-    def dists = ['jessie', 'stretch']
-    for (def i = 0; i < dists.size(); i++) {
-        def dist = dists[i]
-
-        stage("build-${dist}") {
-            node('slave') {
-                step([$class: 'WsCleanup'])
-                unstash 'src'
-                dir('src') {
-                    sh 'make clean'
-                    sh "make package_${dist}"
-                    sh "mv dist dist_${dist}"
-                    archiveArtifacts artifacts: "dist_${dist}/*"
-                }
-                stash 'src'
-            }
-        }
-
-        if (env.BRANCH_NAME == 'master') {
-            stage("upload-${dist}") {
-                build job: 'upload-changes', parameters: [
-                    [$class: 'StringParameterValue', name: 'path_to_changes', value: "dist_${dist}/*.changes"],
-                    [$class: 'StringParameterValue', name: 'dist', value: dist],
-                    [$class: 'StringParameterValue', name: 'job', value: env.JOB_NAME.replace('/', '/job/')],
-                    [$class: 'StringParameterValue', name: 'job_build_number', value: env.BUILD_NUMBER],
-                ]
-            }
-        }
-    }
-
-} catch (err) {
-    def subject = "${env.JOB_NAME} - Build #${env.BUILD_NUMBER} - Failure!"
-    def message = "${env.JOB_NAME} (#${env.BUILD_NUMBER}) failed: ${env.BUILD_URL}"
-
-    if (env.BRANCH_NAME == 'master') {
-        slackSend color: '#FF0000', message: message
-        mail to: 'root@ocf.berkeley.edu', subject: subject, body: message
-    } else {
-        mail to: emailextrecipients([
-            [$class: 'CulpritsRecipientProvider'],
-            [$class: 'DevelopersRecipientProvider']
-        ]), subject: subject, body: message
-    }
-
-    throw err
+  }]
 }
 
+
+pipeline {
+  agent {
+    label 'slave'
+  }
+
+  options {
+    ansiColor('xterm')
+    timeout(time: 1, unit: 'HOURS')
+    timestamps()
+  }
+
+  stages {
+    stage('check-gh-trust') {
+      steps {
+        checkGitHubAccess()
+      }
+    }
+
+    stage('parallel-builds') {
+      steps {
+        script {
+          parallel parallelBuilds
+        }
+      }
+    }
+
+    // Upload packages in series instead of in parallel to avoid a race
+    // condition with a lock file on the package repo
+    stage('upload-packages') {
+      when {
+        branch 'master'
+      }
+      agent {
+        label 'deploy'
+      }
+      steps {
+        script {
+          for(dist in dists) {
+            stage("upload-${dist}") {
+              uploadChanges(dist, "dist_${dist}/*.changes")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    failure {
+      emailNotification()
+    }
+    always {
+      node(label: 'slave') {
+        ircNotification()
+      }
+    }
+  }
+}
 
 // vim: ft=groovy

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,12 @@ pam_trimspaces.so: pam_trimspaces.c
 	$(CC) $(CFLAGS) -fPIC -shared -o "$@" "$<" -lpam
 
 .PHONY: package
-package: package_jessie package_stretch
+package: package_stretch package_buster
 
 .PHONY: package_%
-package_%: dist
+package_%:
 	docker run -e "DIST_UID=$(shell id -u)" -e "DIST_GID=$(shell id -g)" -v $(CURDIR):/mnt:rw "docker.ocf.berkeley.edu/theocf/debian:$*" /mnt/build-in-docker "$*"
-
-dist:
-	mkdir -p "$@"
 
 .PHONY: clean
 clean:
-	rm -f pam_trimspaces.so
+	rm -rf pam_trimspaces.so dist_*

--- a/build-in-docker
+++ b/build-in-docker
@@ -13,4 +13,5 @@ VISUAL=touch dch --local "~deb$(lsb_release -rs | cut -d . -f 1)u"
 debuild -us -uc -sa
 
 shopt -s nullglob
-install -o "$DIST_UID" -g "$DIST_GID" -m 644 ../{*.changes,*.deb,*.dsc,*.tar.*,*.buildinfo} /mnt/dist/
+install -o "$DIST_UID" -g "$DIST_GID" -d "/mnt/dist_$1/"
+install -o "$DIST_UID" -g "$DIST_GID" -m 644 ../{*.changes,*.deb,*.dsc,*.tar.*,*.buildinfo} "/mnt/dist_$1/"


### PR DESCRIPTION
This also adds a build for buster, changes packaging a bit (to follow ocflib a bit more).

I'm thinking that soon I'll try and categorize the different types of builds we have (package build, service build, etc.) and make those into shared steps so that it's easier to maintain each repo, that would be pretty nice.